### PR TITLE
Add DOM Path Breadcrumb Navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tifoo",
   "displayName": "Tifoo – Effortless Tailwind Styling",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Streamline your Tailwind CSS development with real-time inspection and intuitive class management—right in your browser.",
   "author": "syncinsect<syncinsect@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
   },
   "dependencies": {
     "@headlessui/react": "^2.1.10",
-    "plasmo": "0.89.3",
+    "plasmo": "0.90.5",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-window": "^1.8.10"
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "4.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,12 @@ const App: React.FC = () => {
     chrome.runtime.sendMessage({ action: "tifooDeactivated" });
   }, [resetAllState, setIsActive, resetTifooState, resetClassManagement]);
 
+  const handleElementSelect = useCallback((newElement: HTMLElement) => {
+    setHighlightedElement(newElement);
+    setAnimatedRect(newElement.getBoundingClientRect());
+    // Keep floating window position, don't reset position
+  }, [setHighlightedElement, setAnimatedRect]);
+
   useMessageListener(
     setIsActive,
     isActive,
@@ -105,6 +111,7 @@ const App: React.FC = () => {
             isFixed={isFloatingWindowFixed}
             onDeactivate={handleDeactivate}
             onClassChange={updateHighlightAndLines}
+            onElementSelect={handleElementSelect}
             setPosition={setFloatingWindowPosition}
           />
         </>

--- a/src/components/ClassList/ClassTag.tsx
+++ b/src/components/ClassList/ClassTag.tsx
@@ -22,7 +22,7 @@ const ClassTag: React.FC<ClassTagProps> = ({
 
   return (
     <div className="bg-gray-50/50 px-2 py-1 rounded-lg text-xs flex items-center justify-between shadow-sm transition-all duration-200 border border-gray-100">
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center gap-1.5 font-mono">
         <Switch
           checked={isChecked}
           onChange={handleChange}

--- a/src/components/ElementNavigation/DOMPathBreadcrumb.tsx
+++ b/src/components/ElementNavigation/DOMPathBreadcrumb.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { DOMPathItem } from "@/hooks/useElementNavigation";
+
+interface DOMPathBreadcrumbProps {
+  path: DOMPathItem[];
+  onElementSelect: (element: HTMLElement) => void;
+  currentElement: HTMLElement;
+}
+
+const DOMPathBreadcrumb: React.FC<DOMPathBreadcrumbProps> = ({
+  path,
+  onElementSelect,
+  currentElement,
+}) => {
+  const getElementDisplayName = (item: DOMPathItem) => {
+    return item.tagName;
+  };
+
+  const isCurrentElement = (item: DOMPathItem) => {
+    return item.element === currentElement; 
+  };
+
+  return (
+    <div className="dom-path-breadcrumb bg-[#E8F5FE] text-[#1DA1F2] p-1.5 rounded text-xs mb-2 font-bold">
+      <div className="flex flex-wrap gap-1 items-center text-xs">
+        {path.map((item, index) => (
+          <React.Fragment key={`${item.tagName}-${index}`}>
+            {index > 0 && (
+              <span className="text-gray-400 mx-1">{'>'}</span>
+            )}
+            <span
+              onClick={() => onElementSelect(item.element)}
+              className={`cursor-pointer transition-all ${
+                isCurrentElement(item)
+                  ? "text-blue-600 underline"
+                  : "text-gray-600 hover:text-gray-800 hover:underline"
+              }`}
+              title={`Select ${getElementDisplayName(item)}`}
+            >
+              {getElementDisplayName(item)}
+            </span>
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default DOMPathBreadcrumb;

--- a/src/components/ElementNavigation/ElementNavigation.tsx
+++ b/src/components/ElementNavigation/ElementNavigation.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useElementNavigation } from "@/hooks";
+import { DOMPathBreadcrumb } from "@/components";
 
 interface ElementNavigationProps {
   element: HTMLElement;
@@ -10,37 +11,18 @@ const ElementNavigation: React.FC<ElementNavigationProps> = ({
   element,
   onElementSelect,
 }) => {
-  const {
-    getParentElement,
-  } = useElementNavigation(element);
+  const { getDOMPath } = useElementNavigation(element);
 
-  const parentElement = getParentElement();
-
-  const handleElementClick = (targetElement: HTMLElement | null) => {
-    if (targetElement) {
-      onElementSelect(targetElement);
-    }
-  };
-
-  const getElementDisplayName = (el: HTMLElement) => {
-    const tagName = el.tagName.toLowerCase();
-    const className = el.className ? `.${el.className.split(' ')[0]}` : '';
-    const id = el.id ? `#${el.id}` : '';
-    return `${tagName}${id}${className}`;
-  };
+  const domPath = getDOMPath(3); // Get up to 3 levels
 
   return (
     <div className="element-navigation mb-3">
-      <div className="text-xs font-semibold text-gray-600 mb-2">Element Navigation</div>
-      {parentElement && (
-        <button
-          onClick={() => handleElementClick(parentElement)}
-          className="w-full text-left px-2 py-1 text-xs bg-blue-50 hover:bg-blue-100 text-blue-700 rounded border border-blue-200 transition-colors"
-          title={`Select parent element: ${getElementDisplayName(parentElement)}`}
-        >
-          ↑ Select Parent Element
-        </button>
-      )}
+      {/* DOM Path Breadcrumb */}
+      <DOMPathBreadcrumb
+        path={domPath}
+        onElementSelect={onElementSelect}
+        currentElement={element}
+      />
     </div>
   );
 };

--- a/src/components/ElementNavigation/ElementNavigation.tsx
+++ b/src/components/ElementNavigation/ElementNavigation.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { useElementNavigation } from "@/hooks";
+
+interface ElementNavigationProps {
+  element: HTMLElement;
+  onElementSelect: (element: HTMLElement) => void;
+}
+
+const ElementNavigation: React.FC<ElementNavigationProps> = ({
+  element,
+  onElementSelect,
+}) => {
+  const {
+    getParentElement,
+  } = useElementNavigation(element);
+
+  const parentElement = getParentElement();
+
+  const handleElementClick = (targetElement: HTMLElement | null) => {
+    if (targetElement) {
+      onElementSelect(targetElement);
+    }
+  };
+
+  const getElementDisplayName = (el: HTMLElement) => {
+    const tagName = el.tagName.toLowerCase();
+    const className = el.className ? `.${el.className.split(' ')[0]}` : '';
+    const id = el.id ? `#${el.id}` : '';
+    return `${tagName}${id}${className}`;
+  };
+
+  return (
+    <div className="element-navigation mb-3">
+      <div className="text-xs font-semibold text-gray-600 mb-2">Element Navigation</div>
+      {parentElement && (
+        <button
+          onClick={() => handleElementClick(parentElement)}
+          className="w-full text-left px-2 py-1 text-xs bg-blue-50 hover:bg-blue-100 text-blue-700 rounded border border-blue-200 transition-colors"
+          title={`Select parent element: ${getElementDisplayName(parentElement)}`}
+        >
+          ↑ Select Parent Element
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ElementNavigation;

--- a/src/components/FloatingWindow/FloatingWindow.tsx
+++ b/src/components/FloatingWindow/FloatingWindow.tsx
@@ -10,6 +10,7 @@ import {
   ClassList,
   AutoComplete,
   Toast,
+  ElementNavigation,
 } from "@/components";
 
 const FloatingWindow: React.FC<FloatingWindowProps> = ({
@@ -18,6 +19,7 @@ const FloatingWindow: React.FC<FloatingWindowProps> = ({
   isFixed,
   onDeactivate,
   onClassChange,
+  onElementSelect,
   setPosition,
 }) => {
   const floatingWindowRef = useRef<HTMLDivElement>(null);
@@ -80,6 +82,12 @@ const FloatingWindow: React.FC<FloatingWindowProps> = ({
         <div className="bg-[#E8F5FE] text-[#1DA1F2] p-1.5 rounded text-xs mb-2 font-bold">
           {element.tagName.toLowerCase()}
         </div>
+        {onElementSelect && (
+          <ElementNavigation
+            element={element}
+            onElementSelect={onElementSelect}
+          />
+        )}
         <ClassList
           classes={classes}
           element={element}

--- a/src/components/FloatingWindow/FloatingWindow.tsx
+++ b/src/components/FloatingWindow/FloatingWindow.tsx
@@ -79,9 +79,6 @@ const FloatingWindow: React.FC<FloatingWindowProps> = ({
         onDeactivate={onDeactivate}
       />
       <div className="px-3 pb-3">
-        <div className="bg-[#E8F5FE] text-[#1DA1F2] p-1.5 rounded text-xs mb-2 font-bold">
-          {element.tagName.toLowerCase()}
-        </div>
         {onElementSelect && (
           <ElementNavigation
             element={element}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,4 +8,5 @@ export { default as FloatingWindowHeader } from "./FloatingWindow/FloatingWindow
 export { default as ClassList } from "./ClassList/ClassList";
 export { default as HighlightBox } from "./HighlightBox/HighlightBox";
 export { default as ElementNavigation } from "./ElementNavigation/ElementNavigation";
+export { default as DOMPathBreadcrumb } from "./ElementNavigation/DOMPathBreadcrumb";
 export * from "./icons";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,4 +7,5 @@ export { default as FloatingWindow } from "./FloatingWindow/FloatingWindow";
 export { default as FloatingWindowHeader } from "./FloatingWindow/FloatingWindowHeader";
 export { default as ClassList } from "./ClassList/ClassList";
 export { default as HighlightBox } from "./HighlightBox/HighlightBox";
+export { default as ElementNavigation } from "./ElementNavigation/ElementNavigation";
 export * from "./icons";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,6 +4,7 @@ import { useHighlightedIndex } from "./useHighlightedIndex";
 import { useDraggable } from "./useDraggable";
 import { useFloatingWindowLogic } from "./useFloatingWindowLogic";
 import { useElementInfo } from "./useElementInfo";
+import { useElementNavigation } from "./useElementNavigation";
 import { useStyleInjection } from "./useStyleInjection";
 import { useTifooState } from "./useTifooState";
 import { useAnimationEffect } from "./useAnimationEffect";
@@ -15,6 +16,7 @@ export {
   useClassManagement,
   useHighlightedIndex,
   useElementInfo,
+  useElementNavigation,
   useDraggable,
   useFloatingWindowLogic,
   useStyleInjection,

--- a/src/hooks/useElementNavigation.ts
+++ b/src/hooks/useElementNavigation.ts
@@ -1,5 +1,13 @@
 import { useCallback } from "react";
 
+export interface DOMPathItem {
+  element: HTMLElement;
+  tagName: string;
+  className?: string;
+  id?: string;
+  index: number;
+}
+
 export const useElementNavigation = (element: HTMLElement | null) => {
   const getParentElement = useCallback(() => {
     if (!element) return null;
@@ -7,7 +15,41 @@ export const useElementNavigation = (element: HTMLElement | null) => {
     return parent && parent !== document.body ? parent : null;
   }, [element]);
 
+  const getDOMPath = useCallback((maxDepth: number = 3): DOMPathItem[] => {
+    if (!element) return [];
+    
+    const path: DOMPathItem[] = [];
+    let currentElement: HTMLElement | null = element;
+    let depth = 0;
+    
+    while (currentElement && depth < maxDepth) {
+      // Skip body and html elements
+      if (currentElement === document.body || currentElement === document.documentElement) {
+        currentElement = currentElement.parentElement;
+        continue;
+      }
+      
+      const tagName = currentElement.tagName.toLowerCase();
+      const className = currentElement.className ? currentElement.className.split(' ')[0] : undefined;
+      const id = currentElement.id || undefined;
+      
+      path.unshift({
+        element: currentElement,
+        tagName,
+        className,
+        id,
+        index: depth,
+      });
+      
+      currentElement = currentElement.parentElement;
+      depth++;
+    }
+    
+    return path;
+  }, [element]);
+
   return {
     getParentElement,
+    getDOMPath,
   };
 };

--- a/src/hooks/useElementNavigation.ts
+++ b/src/hooks/useElementNavigation.ts
@@ -1,0 +1,13 @@
+import { useCallback } from "react";
+
+export const useElementNavigation = (element: HTMLElement | null) => {
+  const getParentElement = useCallback(() => {
+    if (!element) return null;
+    const parent = element.parentElement;
+    return parent && parent !== document.body ? parent : null;
+  }, [element]);
+
+  return {
+    getParentElement,
+  };
+};

--- a/src/hooks/useTifoo.ts
+++ b/src/hooks/useTifoo.ts
@@ -127,10 +127,9 @@ export const useTifoo = ({
     updateFloatingWindowPosition,
   ]);
   const handleScroll = useCallback(() => {
-    if (isFloatingWindowFixedRef.current && lastHighlightedElement) {
-      setHighlightedElement(lastHighlightedElement);
-    }
-  }, [lastHighlightedElement, setHighlightedElement]);
+    // Don't reset highlighted element on scroll when floating window is fixed
+    // This prevents reverting to the original element when user has selected a parent
+  }, []);
 
   const resetTifooState = useCallback(() => {
     setLastHighlightedElement(null);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,7 @@ export interface FloatingWindowProps {
   isFixed: boolean;
   onDeactivate: () => void;
   onClassChange: () => void;
+  onElementSelect?: (element: HTMLElement) => void;
   setPosition: (position: { x: number; y: number }) => void;
 }
 


### PR DESCRIPTION
- Features
DOM Path Breadcrumb: Shows current element's DOM hierarchy (e.g., div > section > button)
Click Navigation: Click any level to jump directly to that element
Cross-platform Compatibility: Fixed sharp module issues on macOS ARM64
Scroll Fix: Prevent element selection reset when scrolling
- Technical Changes
Added useElementNavigation hook for DOM path functionality
Created DOMPathBreadcrumb component with hover underline effects
Upgraded Plasmo from 0.89.3 to 0.90.5
Fixed package.json syntax error
Removed scroll-triggered element reset logic
- Files Changed
New: src/hooks/useElementNavigation.ts, src/components/ElementNavigation/DOMPathBreadcrumb.tsx
Modified: Element navigation components, App.tsx, useTifoo hook, package.json
- Benefits
Easy selection of hard-to-click parent elements
Visual DOM hierarchy representation
Improved cross-platform development experience
Better UX for complex DOM structures
Labels: enhancement, ui/ux, cross-platform